### PR TITLE
Add UPNP setup check for multiplayer server

### DIFF
--- a/scripts/world.gd
+++ b/scripts/world.gd
@@ -104,6 +104,7 @@ func remove_player(peer_id: int) -> void:
 		player.queue_free()
 
 func upnp_setup() -> void:
+	if multiplayer.is_server(): return
 	var upnp: UPNP = UPNP.new()
 
 	upnp.discover()


### PR DESCRIPTION
It fixes "upnp_setup(): Couldn't find any UPNPDevices." error as shown below:

```
world.gd:110 @ upnp_setup(): Couldn't find any UPNPDevices.
  <C++ Error>  Condition "devices.is_empty()" is true. Returning: nullptr
  <C++ Source> modules/upnp/upnp_miniupnp.cpp:267 @ get_gateway()
  <Stack Trace>world.gd:110 @ upnp_setup()
                world.gd:72 @ _on_host_button_pressed()
```